### PR TITLE
FEATURE: Only show language prompt in enabled categories

### DIFF
--- a/assets/javascripts/discourse/initializers/language-preference-modal.js
+++ b/assets/javascripts/discourse/initializers/language-preference-modal.js
@@ -17,6 +17,32 @@ export default {
 
       let pendingModalTimeoutId = null;
 
+      const isInEnabledCategory = () => {
+        const siteSettings = api.container.lookup("service:site-settings");
+        const enabledCategories =
+          siteSettings.babel_reunited_enabled_categories;
+        if (!enabledCategories) {
+          return true;
+        }
+
+        const allowedIds = enabledCategories.split("|").map(Number);
+        const router = api.container.lookup("service:router");
+        let route = router.currentRoute;
+        while (route) {
+          const attrs = route.attributes;
+          if (attrs) {
+            if (attrs.category?.id !== undefined) {
+              return allowedIds.includes(attrs.category.id);
+            }
+            if (attrs.category_id !== undefined) {
+              return allowedIds.includes(attrs.category_id);
+            }
+          }
+          route = route.parent;
+        }
+        return false;
+      };
+
       const scheduleModalShow = () => {
         if (
           currentUser.preferred_language_enabled === false ||
@@ -26,6 +52,10 @@ export default {
         }
 
         if (localStorage.getItem("language_preference_modal_shown")) {
+          return;
+        }
+
+        if (!isInEnabledCategory()) {
           return;
         }
 

--- a/assets/javascripts/discourse/initializers/language-preference-modal.js
+++ b/assets/javascripts/discourse/initializers/language-preference-modal.js
@@ -11,14 +11,15 @@ export default {
 
       const modal = api.container.lookup("service:modal");
       const messageBus = api.container.lookup("service:message-bus");
-      if (!modal || !messageBus) {
+      const siteSettings = api.container.lookup("service:site-settings");
+      const router = api.container.lookup("service:router");
+      if (!modal || !messageBus || !siteSettings || !router) {
         return;
       }
 
       let pendingModalTimeoutId = null;
 
       const isInEnabledCategory = () => {
-        const siteSettings = api.container.lookup("service:site-settings");
         const enabledCategories =
           siteSettings.babel_reunited_enabled_categories;
         if (!enabledCategories) {
@@ -26,7 +27,6 @@ export default {
         }
 
         const allowedIds = enabledCategories.split("|").map(Number);
-        const router = api.container.lookup("service:router");
         let route = router.currentRoute;
         while (route) {
           const attrs = route.attributes;


### PR DESCRIPTION
## Summary
- Language preference modal now only appears when the user is browsing a page within a translation-enabled category
- Walks the Ember route hierarchy to detect the current category (works for both category listing and topic pages)
- When `babel_reunited_enabled_categories` is blank (all categories enabled), behavior is unchanged — prompt shows on any page
- Consistent with how `language-tabs` checks `enabled_categories` (same `split("|").map(Number)` pattern)

## Test plan
- [x] `bin/lint` — prettier + eslint clean
- [ ] Manual: set `babel_reunited_enabled_categories` to a single category, visit that category → modal should appear
- [ ] Manual: visit a different category → modal should NOT appear
- [ ] Manual: clear `babel_reunited_enabled_categories` → modal should appear on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)